### PR TITLE
fix capitalize problem when "I" is not first letter of the string

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -22,6 +22,7 @@ class TestTurkishWords(unittest.TestCase):
     ]
 
     CAPITALIZE_CASES = [
+        {"word": u"KADIKÖY", "capitalize": u"Kadıköy"},
         {"word": u"çınar", "capitalize": u"Çınar"},
         {"word": u"şansal", "capitalize": u"Şansal"},
         {"word": u"istanbul", "capitalize": u"İstanbul",}
@@ -32,7 +33,7 @@ class TestTurkishWords(unittest.TestCase):
         {"phrase": u"ısparta istanbul", "title": u"Isparta İstanbul"},
         {"phrase": u"İstanbul", "title": u"İstanbul"},
         {"phrase": u"çarşı timu", "title": u"Çarşı Timu"},
-        {"phrase": u"Ğaaa ÇEŞİL", "title": u"Ğaaa Çeşil"},
+        {"phrase": u"Ğaaa ÇEŞİL KADIKÖY", "title": u"Ğaaa Çeşil Kadıköy"},
         {"phrase": u"ŞamaTa ısparta istanbul", "title": u"Şamata Isparta İstanbul"},
     ]
 

--- a/unicode_tr/__init__.py
+++ b/unicode_tr/__init__.py
@@ -27,10 +27,7 @@ class unicode_tr(unicode):
 
     def capitalize(self):
         first, rest = self[0], self[1:]
-        for key, value in self.CHARMAP.get("to_upper").items():
-            first = first.replace(key, value)
-
-        return (first + rest).capitalize()
+        return unicode_tr(first).upper() + unicode_tr(rest).lower()
 
     def title(self):
         return " ".join(map(lambda x: unicode_tr(x).capitalize(), self.split()))


### PR DESCRIPTION
``` python
from unicode_tr import unicode_tr
print unicode_tr(u"KADIKOY").capitalize()
```

prints **Kadikoy** but it should print **Kadıkoy**.
