### PR TITLE
[FIX] https://github.com/emre/unicode_tr/issues/8

### DIFF
--- a/unicode_tr/__init__.py
+++ b/unicode_tr/__init__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf8 -*-
 
 try:
-    __instance = unicode
+    __instance__ = unicode
 except:
-    __instance = str
+    __instance__ = str
 
-class unicode_tr(__instance):
+
+class unicode_tr(__instance__):
     CHARMAP = {
         "to_upper": {
             u"ı": u"I",
@@ -21,17 +22,20 @@ class unicode_tr(__instance):
         for key, value in self.CHARMAP.get("to_lower").items():
             self = self.replace(key, value)
 
-        return self.lower()
+        return unicode_tr(getattr(__instance__, 'lower')(self))
 
     def upper(self):
         for key, value in self.CHARMAP.get("to_upper").items():
             self = self.replace(key, value)
 
-        return self.upper()
+        return unicode_tr(getattr(__instance__, 'upper')(self))
+
+    def replace(self, *args, **kwargs):
+        return unicode_tr(getattr(__instance__, 'replace')(self, args[0], args[1]))
 
     def capitalize(self):
         first, rest = self[0], self[1:]
         return unicode_tr(first).upper() + unicode_tr(rest).lower()
 
     def title(self):
-        return " ".join(map(lambda x: unicode_tr(x).capitalize(), self.split()))
+        return " ".join(map(lambda x: unicode_tr(x).capitalize(), self.split())).title()

--- a/unicode_tr/__init__.py
+++ b/unicode_tr/__init__.py
@@ -35,7 +35,7 @@ class unicode_tr(__instance__):
 
     def capitalize(self):
         first, rest = self[0], self[1:]
-        return unicode_tr(first).upper() + unicode_tr(rest).lower()
+        return unicode_tr(unicode_tr(first).upper() + unicode_tr(rest).lower())
 
     def title(self):
-        return " ".join(map(lambda x: unicode_tr(x).capitalize(), self.split())).title()
+        return unicode_tr(" ".join(map(lambda x: unicode_tr(x).capitalize(), self.split())).title())

--- a/unicode_tr/extras.py
+++ b/unicode_tr/extras.py
@@ -3,19 +3,19 @@
 import unicodedata
 import re
 
-from . import __instance
-    
+from . import __instance__
+
+
 def slugify(value):
     """
     django.utils.text.slugify
     patched for ı and İ chars.
     """
-    if not isinstance(value, __instance):
-        value = __instance(value, 'utf8')
+    if not isinstance(value, __instance__):
+        value = __instance__(value, 'utf8')
 
     value = value.replace(u'\u0131', 'i')
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
     value = re.sub('[^\w\s-]', '', value).strip().lower()
 
     return re.sub('[-\s]+', '-', value)
-


### PR DESCRIPTION
### Bug 1:

Check https://github.com/emre/unicode_tr/issues/8

### Bug 2:

title() method doesn't work properly. 
>>> from unicode_tr import unicode_tr
>>> text = unicode_tr("ZEYNET MAH (BÜKARDI BELDESİ)")
>>> text.title()
'Zeynet Mah (bükardı Beldesi)'

The result should be: 'Zeynet Mah (Bükardı Beldesi)'. It's fixed now.

At the same time, it would be better for compatibility to have all returns in the unicode_tr class since it's already inherited unicode or str types.

### Tests

Python3:   
Ran 5 tests in 0.001s

OK

Python2:
Ran 5 tests in 0.000s

OK



